### PR TITLE
fix: rename 90-alsa-restore.rules to 90-amlogic-soundconfig.rules

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Priority: optional
 Standards-Version: 4.6.0
 Build-Depends: debhelper (>=12~),
                devscripts,
+               dh-exec,
                lintian,
 
 Package: libreelec-alsa-utils

--- a/debian/install
+++ b/debian/install
@@ -1,2 +1,4 @@
+#!/usr/bin/dh-exec
+
 src/packages/audio/alsa-utils/scripts/soundconfig usr/lib/udev/
-src/packages/audio/alsa-utils/udev.d/90-alsa-restore.rules usr/lib/udev/rules.d/
+src/packages/audio/alsa-utils/udev.d/90-alsa-restore.rules => usr/lib/udev/rules.d/90-libreelec-soundconfig.rules


### PR DESCRIPTION
Because alsa-ucm-conf also includes 90-alsa-restore.rules

To avoid conflicts, it needs to be renamed